### PR TITLE
Remove cmake from `build-packages`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,8 +22,6 @@ parts:
     plugin: rust
     source: https://github.com/astral-sh/uv.git
     source-tag: $SNAPCRAFT_PROJECT_VERSION
-    build-packages:
-      - cmake
     build-attributes:
       - enable-patchelf
     build-environment:


### PR DESCRIPTION
uv no longer requires cmake; see https://github.com/astral-sh/uv/pull/11894
